### PR TITLE
Add new niktest/solaredge_ev_charger_au integration

### DIFF
--- a/integration
+++ b/integration
@@ -733,6 +733,7 @@
   "nielsfaber/scheduler-component",
   "nimroddolev/akuvox",
   "nimroddolev/chime_tts",
+  "niktest/solaredge_ev_charger_au",
   "NinDTendo/homeassistant_gradual_volume_control",
   "NinDTendo/tobi",
   "nkvoll/home-assistant-qsys-qrc",


### PR DESCRIPTION
<!--
DO NOT REQUEST REVIEWS, THAT IS JUST RUDE, IF YOU DO THE PULL REQUEST WILL BE CLOSED!
Make sure to check out the guide here: https://hacs.xyz/docs/publish/start
-->
## Checklist

<!-- Do not open a pull request before you have completed all these, it will be closed. -->

- [x] I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
- [x] I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
- [x] (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
- [x] The actions are passing without any disabled checks in my repository.
- [x] I've added a link to the action run on my repository below in the links section.
- [x] I've created a new release of the repository after the validation actions were run successfully.

## Links

<!-- Do not open a pull request before you have provided all these, it will be closed. -->

Link to current release: https://github.com/niktest/solaredge_ev_charger_au/releases/tag/1.0.0
Link to successful HACS action (without the `ignore` key): https://github.com/niktest/solaredge_ev_charger_au/actions/runs/12946594178/job/36111434399
Link to successful hassfest action (if integration): https://github.com/niktest/solaredge_ev_charger_au/actions/runs/12946594178/job/36111434666

